### PR TITLE
Blocage du datepicker

### DIFF
--- a/src/AppBundle/Resources/views/Front/createObservation.html.twig
+++ b/src/AppBundle/Resources/views/Front/createObservation.html.twig
@@ -123,6 +123,7 @@
         $(function () {
             $('.input-group.date').datetimepicker({
                 locale: "{{ app.request.locale }}",
+                maxDate: moment(),
                 format: 'DD/MM/YYYY'
             });
         });


### PR DESCRIPTION
Blocage du datepicker dans la saisie observation pour empecher de saisir
une date supérieure à celle du jour.